### PR TITLE
Add 2 pixel border between avatars

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -145,6 +145,11 @@ namespace AvatarGetter
 
         // All FRC avatars are 40x40.
         public const int AVATAR_SIZE = 40;
+        // Each sprite has a 2 pixel border between it and the next sprite
+        // so that when the whole sprite sheet is resized the avatars
+        // do not bleed into each other. Otherwise borders appear on some
+        // avatars on certain displays.
+        public const int AVATAR_BORDER = 2;
 
         static async Task<List<Avatar>> DownloadAvatars()
         {
@@ -250,7 +255,7 @@ namespace AvatarGetter
             }
 
             int sheetSize = (int)Math.Ceiling(Math.Sqrt(avatars.Count));
-            Image<Rgba32> sheet = new Image<Rgba32>(sheetSize * AVATAR_SIZE, sheetSize * AVATAR_SIZE);
+            Image<Rgba32> sheet = new Image<Rgba32>(sheetSize * (AVATAR_SIZE + AVATAR_BORDER), sheetSize * (AVATAR_SIZE + AVATAR_BORDER));
 
             // The (new) avatar locations in the spritesheet
             AvatarInfo avatarInfo = new AvatarInfo(sheetSize);
@@ -260,8 +265,8 @@ namespace AvatarGetter
             for (int i = 0; i < avatars.Count; i++)
             {
                 Avatar avatar = avatars[i];
-                int x = (i % sheetSize) * AVATAR_SIZE;
-                int y = (i / sheetSize) * AVATAR_SIZE;
+                int x = (i % sheetSize) * (AVATAR_SIZE + AVATAR_BORDER);
+                int y = (i / sheetSize) * (AVATAR_SIZE + AVATAR_BORDER);
 
                 avatar.DrawToSpritesheet(sheet, x, y);
                 avatarInfo.locations.Add(avatar.TeamNumber, new Loc(x, y));


### PR DESCRIPTION
On some displays, when google maps draws the avatars (which are 40x40) as 30x30, it results in borders around the avatar (see image below) because when google maps downscales the avatar spritesheet some of the bordering pixels from other avatars bleed over. This adds a 2 pixel blank border between avatars, which prevents other avatars from bleeding in around the edges. When this is merged, I will update FIRSTMap to account for this.

![image](https://user-images.githubusercontent.com/9920632/69924452-7123ee80-1479-11ea-8c41-16ad662baa93.png)
